### PR TITLE
chore: bump provider dependency to go-opnsense v0.4.3

### DIFF
--- a/provider/core/unbound/host_alias.go
+++ b/provider/core/unbound/host_alias.go
@@ -2,6 +2,9 @@ package unbound
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/oss4u/go-opnsense/opnsense"
 	gooverrides "github.com/oss4u/go-opnsense/opnsense/core/unbound/overrides"
@@ -168,5 +171,70 @@ func (h HostAliasOverride) createHostAlias(ctx context.Context, args *HostAliasO
 	if err != nil {
 		return "", err
 	}
-	return createdAlias.Alias.Uuid, nil
+
+	if createdAlias != nil {
+		if id := strings.TrimSpace(createdAlias.Alias.Uuid); id != "" {
+			return id, nil
+		}
+	}
+
+	resolvedID, resolveErr := h.findHostAliasUUIDByHostDomain(ctx, *args.Hostname, *args.Domain)
+	if resolveErr != nil {
+		return "", resolveErr
+	}
+	if resolvedID == "" {
+		return "", fmt.Errorf("host alias was created but no uuid was returned for %s.%s", *args.Hostname, *args.Domain)
+	}
+
+	return resolvedID, nil
+}
+
+func (h HostAliasOverride) findHostAliasUUIDByHostDomain(ctx context.Context, hostname, domain string) (string, error) {
+	cfg := infer.GetConfig[config.Config](ctx)
+	if cfg.Api == nil {
+		cfg.Api = opnsense.GetOpnSenseClient(cfg.Address, cfg.Key, cfg.Secret)
+	}
+
+	searchPayload := map[string]any{
+		"current":  1,
+		"rowCount": 500,
+	}
+
+	payloadRaw, err := json.Marshal(searchPayload)
+	if err != nil {
+		return "", err
+	}
+
+	raw, err := cfg.Api.ModifyingRequest("unbound", "settings", "search_host_alias", string(payloadRaw), []string{})
+	if err != nil {
+		return "", err
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return "", err
+	}
+
+	rows, ok := decoded["rows"].([]any)
+	if !ok {
+		return "", nil
+	}
+
+	for _, row := range rows {
+		rowMap, ok := row.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		candidateHost, _ := rowMap["hostname"].(string)
+		candidateDomain, _ := rowMap["domain"].(string)
+		uuid, _ := rowMap["uuid"].(string)
+
+		if strings.EqualFold(strings.TrimSpace(candidateHost), strings.TrimSpace(hostname)) &&
+			strings.EqualFold(strings.TrimSpace(candidateDomain), strings.TrimSpace(domain)) {
+			return strings.TrimSpace(uuid), nil
+		}
+	}
+
+	return "", nil
 }

--- a/provider/core/unbound/host_override.go
+++ b/provider/core/unbound/host_override.go
@@ -2,6 +2,9 @@ package unbound
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/oss4u/go-opnsense/opnsense"
 	gooverrides "github.com/oss4u/go-opnsense/opnsense/core/unbound/overrides"
@@ -174,5 +177,70 @@ func (h HostOverride) createHostOverride(ctx context.Context, args *HostOverride
 	if err != nil {
 		return "", err
 	}
-	return createdHost.Host.GetUUID(), err
+
+	if createdHost != nil {
+		if id := strings.TrimSpace(createdHost.Host.GetUUID()); id != "" {
+			return id, nil
+		}
+	}
+
+	resolvedID, resolveErr := h.findHostOverrideUUIDByHostDomain(ctx, *args.Hostname, *args.Domain)
+	if resolveErr != nil {
+		return "", resolveErr
+	}
+	if resolvedID == "" {
+		return "", fmt.Errorf("host override was created but no uuid was returned for %s.%s", *args.Hostname, *args.Domain)
+	}
+
+	return resolvedID, nil
+}
+
+func (h HostOverride) findHostOverrideUUIDByHostDomain(ctx context.Context, hostname, domain string) (string, error) {
+	cfg := infer.GetConfig[config.Config](ctx)
+	if cfg.Api == nil {
+		cfg.Api = opnsense.GetOpnSenseClient(cfg.Address, cfg.Key, cfg.Secret)
+	}
+
+	searchPayload := map[string]any{
+		"current":  1,
+		"rowCount": 500,
+	}
+
+	payloadRaw, err := json.Marshal(searchPayload)
+	if err != nil {
+		return "", err
+	}
+
+	raw, err := cfg.Api.ModifyingRequest("unbound", "settings", "search_host_override", string(payloadRaw), []string{})
+	if err != nil {
+		return "", err
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return "", err
+	}
+
+	rows, ok := decoded["rows"].([]any)
+	if !ok {
+		return "", nil
+	}
+
+	for _, row := range rows {
+		rowMap, ok := row.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		candidateHost, _ := rowMap["hostname"].(string)
+		candidateDomain, _ := rowMap["domain"].(string)
+		uuid, _ := rowMap["uuid"].(string)
+
+		if strings.EqualFold(strings.TrimSpace(candidateHost), strings.TrimSpace(hostname)) &&
+			strings.EqualFold(strings.TrimSpace(candidateDomain), strings.TrimSpace(domain)) {
+			return strings.TrimSpace(uuid), nil
+		}
+	}
+
+	return "", nil
 }

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/oss4u/go-opnsense v0.4.2
+	github.com/oss4u/go-opnsense v0.4.3
 	github.com/pulumi/pulumi-go-provider v1.3.0
 	github.com/pulumi/pulumi/sdk/v3 v3.223.0
 	github.com/stretchr/testify v1.11.1

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -161,8 +161,8 @@ github.com/opentracing/basictracer-go v1.1.0/go.mod h1:V2HZueSJEp879yv285Aap1BS6
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/oss4u/go-opnsense v0.4.2 h1:f/YV4pH+pLasMUu/y7xe8mZ6x1FjmUFzoaYqVmcl+vs=
-github.com/oss4u/go-opnsense v0.4.2/go.mod h1:5UuagYKuwr762di5r50cbcLVj7BeKrZ88vYLaYNUzss=
+github.com/oss4u/go-opnsense v0.4.3 h1:VMqmk5PAjDrk/eLGFgsEyI+aIzfbgpX/XcIlQnPFmWg=
+github.com/oss4u/go-opnsense v0.4.3/go.mod h1:5UuagYKuwr762di5r50cbcLVj7BeKrZ88vYLaYNUzss=
 github.com/pact-foundation/pact-go/v2 v2.4.2 h1:hRHKoniPzKdFeGdUFuWbKfl8IHxrWH9nxr+DkYGR5zI=
 github.com/pact-foundation/pact-go/v2 v2.4.2/go.mod h1:C6v9PYc1RvGEvO3Oz2JEJ4kjHjQOm3QyOM3xQo2soMQ=
 github.com/pgavlin/fx v0.1.6 h1:r9jEg69DhNoCd3Xh0+5mIbdbS3PqWrVWujkY76MFRTU=


### PR DESCRIPTION
## Summary\n- update provider module dependency from go-opnsense v0.4.2 to v0.4.3\n- include the UUID resolution fix release from go-opnsense in pulumi-opnsense\n\n## Validation\n- cd provider\n- go test ./...